### PR TITLE
Update to GitLab 8.3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -257,7 +257,7 @@ password: [MySQL Passwort] #Wenn es nicht geändert wurde, dann unter ~/.my.cnf 
 `nano config/environments/production.rb`
 
 ```ruby
-config.serve_static_assets = true
+config.serve_static_files = true
 ```
 
 

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,6 @@ export PATH=$HOME/.gem/ruby/2.1.0/bin:$PATH
 __EOF__
 ```
 
-
 #### .bashrc vs. .bash_profile ####
 SSH Keys werden innerhalb GitLab über die GitLab Shell verwaltet. Da diese SSH Keys direkt auf das GL Shell Script verweisen wird `.bash_profile` nicht geladen.
 Seid ihr der Anleitung auf [Uberspace](https://wiki.uberspace.de/development:ruby) gefolgt, müssen daher die `$PATH` Angaben aus der `.bash_profile` in `.bashrc` verschoben (oder kopiert) werden.

--- a/Readme.md
+++ b/Readme.md
@@ -316,8 +316,8 @@ Eine kurze Anleitung und die Service-Skripte findet ihr in seiner eigenen [GitLa
 - [sidekiq-Service](services/sidekiq) *man beachte den neuen Parameter `-q archive_repo` um Downloads von Repositories als gepacktes Archiv zu ermöglichen*
 - [gitlab-Service](services/gitlab) (Unicorn)
 
-**Und für den Neuen git-http-server:**
-- [git-http-server-Service](services/gitlab-workhorse)
+**Und für das neue gitlab-workhorse:**
+- [gitlab-workhorse-Service](services/gitlab-workhorse)
 
 In dem Script sind am Anfang zwei Ports anzugeben.
 1. Für `[your unicorn port]` nehmen wir den unter [unicorn.rb Konfiguration](#unicornrb-konfiguration) ausgewählten Port für den Unicorn-Webserver.

--- a/services/Readme.md
+++ b/services/Readme.md
@@ -19,3 +19,12 @@ Setup deamons according to [uberspace documentation](https://wiki.uberspace.de/s
     uberspace-setup-service git-http-server ~/bin/git-http-server
 
 That's it! Happy coding :-)
+
+## update from git-http-server to gitlab-workhorse
+    cd ~/service/git-http-server
+    rm ~/service/git-http-server
+    svc -dx . log
+    rm -rf ~/etc/run-git-http-server
+    cd ~/bin
+    mv git-http-server.sh gitlab-workhorse.sh
+    uberspace-setup-service gitlab-workhorse ~/bin/gitlab-workhorse.sh

--- a/services/gitlab-workhorse
+++ b/services/gitlab-workhorse
@@ -4,7 +4,7 @@ unicorn_port=[your unicorn port]
 export GITLAB_PATH="$HOME/gitlab"
 pid_path="$GITLAB_PATH/tmp/pids"
 socket_path="$GITLAB_PATH/tmp/sockets"
-filename="gitlab-git-http-server"
+filename="gitlab-workhorse"
 
 gitlab_git_http_server_options="-listenUmask 0 -listenNetwork tcp -listenAddr localhost:$http_port -authBackend http://127.0.0.1:$unicorn_port"
 gitlab_git_http_server_repo_root="$HOME/repositories"


### PR DESCRIPTION
Bitteschön, ein Update auf GitLab 8.3.
Umbenennung von git-http-server -> gitlab-workhorse.

Bei mir funktioniert alles ohne Fehlermeldungen, lediglich der Download eines Repositorys als .zip funktioniert nicht mehr mit der aktuellen Version. Eventuell funktioniert das mit der nächsten Version ja wieder.
