### PR TITLE
Corrected sidekiq misspelling

### DIFF
--- a/services/sidekiq
+++ b/services/sidekiq
@@ -34,4 +34,4 @@ app_root=$GITLAB_PATH
 sidekiq_pidfile="$app_root/tmp/pids/sidekiq.pid"
 sidekiq_logfile="$app_root/log/sidekiq.log"
 
-exec bundle exec sidekiq -q post_receive -q mailer -q system_hook -q project_web_hook -q archive_repo -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile >> $sidekiq_logfile 2>&1
+exec bundle exec sidekiq -q post_receive -q mailers -q system_hook -q project_web_hook -q archive_repo -q gitlab_shell -q common -q default -e $RAILS_ENV -P $sidekiq_pidfile >> $sidekiq_logfile 2>&1


### PR DESCRIPTION
Corrected Mailer queue name (in 8.3.2 it's mailers: https://github.com/gitlabhq/gitlabhq/commit/9ce8c867eeb5da53eb76bc01ef7eaef5c798243c)
