### PR TITLE
Anpassung für v8.12: .gitlab_workhorse_secret

### DIFF
--- a/services/gitlab-workhorse
+++ b/services/gitlab-workhorse
@@ -6,7 +6,8 @@ pid_path="$GITLAB_PATH/tmp/pids"
 socket_path="$GITLAB_PATH/tmp/sockets"
 filename="gitlab-workhorse"
 
-gitlab_git_http_server_options="-listenUmask 0 -listenNetwork tcp -listenAddr localhost:$http_port -authBackend http://127.0.0.1:$unicorn_port"
+gitlab_workhorse_secret="$GITLAB_PATH/.gitlab_workhorse_secret"
+gitlab_git_http_server_options="-listenUmask 0 -listenNetwork tcp -listenAddr localhost:$http_port -authBackend http://127.0.0.1:$unicorn_port -secretPath $gitlab_workhorse_secret"
 gitlab_git_http_server_repo_root="$HOME/repositories"
 gitlab_git_http_server_log="$GITLAB_PATH/log/$filename.log"
 


### PR DESCRIPTION
Gitlab Workhorse muss seit Version 8.12 die Datei `.gitlab_workhorse_secret` lesen können.
Mit dem Parameter `-secretPath` kann der Pfad angeben werden. Ohne versucht Workhorse die Datei unter `$HOME` zu finden.

Inspiriert von https://gitlab.com/gitlab-org/omnibus-gitlab/issues/1595
