### PR TITLE
Update "Precompile assets" for 8.17

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -293,7 +293,7 @@ bundle exec rake gitlab:setup RAILS_ENV=production
 ## Precompile assets ##
 
 ```bash
-bundle exec rake assets:precompile RAILS_ENV=production
+bundle exec rake gitlab:assets:clean gitlab:assets:compile cache:clear RAILS_ENV=production
 ```
 
 Dieser Vorgang kann eine Weile dauern...


### PR DESCRIPTION
Since 8.16 the Rake tasks have changed for compiling assets. Starting with 8.17 the new task "gitlab:assets:compile" also takes care of compiling the required webpack assets.